### PR TITLE
The keyboard adapts its layout regarding the size of the vkb window, and...

### DIFF
--- a/qml/OrientationHelper.qml
+++ b/qml/OrientationHelper.qml
@@ -1,9 +1,0 @@
-import QtQuick 2.0
-
-Item {
-    anchors.fill: parent
-
-    property bool automaticOrientation: false
-    property int orientationAngle: 0
-    property bool transitionEnabled: false
-}

--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -484,22 +484,18 @@ void InputMethod::onVisibleRectChanged()
 {
     Q_D(InputMethod);
 
-    QRect visibleRect = qGuiApp->primaryScreen()->mapBetween(
-                            d->m_geometry->orientation(),
-                            qGuiApp->primaryScreen()->primaryOrientation(),
-                            d->m_geometry->visibleRect().toRect());
-
-    inputMethodHost()->setScreenRegion(QRegion(visibleRect));
-    inputMethodHost()->setInputMethodArea(visibleRect, d->view);
-    d->view->setHeight(d->m_geometry->canvasHeight());
-    d->view->setMask(QRegion(d->m_geometry->visibleRect().toRect()));
+    QRect visibleRect = d->m_geometry->visibleRect().toRect();
 
     qDebug() << "keyboard is reporting <x y w h>: <"
                 << visibleRect.x()
                 << visibleRect.y()
                 << visibleRect.width()
                 << visibleRect.height()
-                << "> to the app manager.";
+                << "> as a new visibleRect.";
+
+    inputMethodHost()->setScreenRegion(QRegion(visibleRect));
+    inputMethodHost()->setInputMethodArea(visibleRect, d->view);
+    d->view->setMask(QRegion(d->m_geometry->visibleRect().toRect()));
 
     d->applicationApiWrapper->reportOSKVisible(
                 visibleRect.x(),


### PR DESCRIPTION
... doesn't try to guess what screen orientation is currently used.

The usage now is to have the vkb covering almost all the screen, and to use the window mask to have the current touch behavior.

Signed-off-by: Christophe Chapuis <chris.chapuis@gmail.com>