### PR TITLE
inputmethod: don't hide at reset

### DIFF
--- a/qml/keys/DismissKey.qml
+++ b/qml/keys/DismissKey.qml
@@ -35,7 +35,7 @@ ActionKey {
         onlyExclusive: true
 
         onKeyReleased: {
-            maliit_geometry.shown = false;
+            maliit_input_method.hide();
         }
 
         onKeyPressedAndHold: {

--- a/src/plugin/inputmethod.cpp
+++ b/src/plugin/inputmethod.cpp
@@ -159,7 +159,6 @@ void InputMethod::hide()
 
 void InputMethod::reset()
 {
-    hide();
 }
 
 void InputMethod::setPreedit(const QString &preedit,


### PR DESCRIPTION
reset is supposed to reset the internal state, but not to change the current hide/show status.

This mistake was introduced in 32f6db5bca2f0982452f96a076dfc2034747c445